### PR TITLE
chore: add submodule with relative URL to .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,5 +2,9 @@
 	path = submodules/sample-namespace-packages
 	url = https://github.com/pypa/sample-namespace-packages.git
 [submodule "submodules/non-existent-path"]
-    path = submodules/non-existent-path
-    url = git@github.com:pypa/sampleproject.git
+	path = submodules/non-existent-path
+	url = git@github.com:pypa/sampleproject.git
+[submodule "submodules/relative-url-submodule"]
+	path = submodules/relative-url-submodule
+	url = ../test-fixture-vcs-repository.git
+	branch = standalone_branch


### PR DESCRIPTION
Successor to #4, which was not entirely correct and could not be amended as it was made off the master branch.

Introduce a relative URL submodule as a test fixture based on a branch on this same repository with no history.

Co-authored by @evanrittenhouse 
